### PR TITLE
[FIX] website_portal: Keep country changes

### DIFF
--- a/addons/website_portal/views/templates.xml
+++ b/addons/website_portal/views/templates.xml
@@ -113,7 +113,7 @@
                                         <select name="country_id" class="form-control">
                                             <option value="">Country...</option>
                                             <t t-foreach="countries or []" t-as="country">
-                                                <option t-att-value="country.id" t-att-selected="country.id == partner.country_id.id">
+                                                <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id">
                                                     <t t-esc="country.name" />
                                                 </option>
                                             </t>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a portal user changes his account details and presses the 'Save' button when a mandatory field is not set, the selected country will be reset even when the user did change the country in the form. This fix prevents this from happening and leads to an improvement for the end user.

Actions:
- Go to the 'Change details' form on the portal
- Change your country
- Make a mandatory field (e.g. City) blank
- Hit 'Save'

Current behavior before PR:
All changed fields BUT country are still the same as they were before pressing the 'Save' button.

Desired behavior after PR is merged:
All changed fields INCLUDING country are still the same as they were before pressing the 'Save' button

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
