### PR TITLE
[FIX]: Project labels read access

### DIFF
--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -142,7 +142,7 @@
                             <thead>
                                 <tr class="active">
                                     <th t-if="groupby == 'none'" class="col-md-9">Name</th>
-                                    <th t-else="" class="col-md-9"><span t-field="tasks[0].project_id.label_tasks"/> for project: <span t-field="tasks[0].project_id.name"/></th>
+                                    <th t-else="" class="col-md-9"><span t-field="tasks[0].project_id.sudo().label_tasks"/> for project: <span t-field="tasks[0].project_id.sudo().name"/></th>
                                     <th class="col-md-2">Stage</th>
                                     <th>Ref</th>
                                 </tr>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a portal user is a follower on a task, but not a follower on the parent project, an internal server error occured when navigating to URL/my/tasks.

Current behavior before PR:
* Add a portal user as follower on a project task.
* Make sure he isn't a follower of the parent project.
* Log in with portal user account.
* Go to My account > Tasks.
* Internal server error.

Desired behavior after PR is merged:
* Add a portal user as follower on a project task.
* Make sure he isn't a follower of the parent project.
* Log in with portal user account.
* Go to My account > Tasks.
* You see an overview with all your tasks.

Tested on http://365018-11-0-65ef27.runbot14.odoo.com
![image](https://user-images.githubusercontent.com/17778757/44524890-6e1b4980-a6df-11e8-85ad-ec5e9ca34eae.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
